### PR TITLE
Fix : Hitting normal monster can resume meter at BS normal

### DIFF
--- a/Soulworker Utility/Damage Meter/Damage Meter.cpp
+++ b/Soulworker Utility/Damage Meter/Damage Meter.cpp
@@ -55,20 +55,29 @@ VOID SWDamageMeter::AddDamage(UINT32 id, UINT64 totalDMG, UINT64 soulstoneDMG, S
 	if (_mazeEnd)
 		return;
 
-
-	SW_DB2_STRUCT* db = DAMAGEMETER.GetMonsterDB(monsterID);
-	UINT32 db2 = 0;
-	if (db != nullptr) {
-		db2 = db->_db2;
-	}
-	// 타이머가 멈춰있고 퍼펫구슬/옥타곤/폭심지 때린거면 무시
-	if (!isRun() && (resumeIgnoreIdList.find(db2) != resumeIgnoreIdList.end()))
-		return;
-
-	// 메이즈 들어와서 켰을경우에도 무시
+	// Meter must know mazeId to work correctly
 	if (GetWorldID() == 0)
 		return;
 
+	SW_DB2_STRUCT* db = DAMAGEMETER.GetMonsterDB(monsterID);
+	UINT32 monsterId = 0;
+	if (db != nullptr) {
+		monsterId = db->_db2;
+	}
+
+	if (!isRun()) {
+		// Do not start/resume if it is damage to Puppet Orb,Ephnel Octagon, or Nabi Bomb wick
+		if (resumeIgnoreIdList.find(monsterId) != resumeIgnoreIdList.end()) {
+			return;
+		}
+
+		// If it is BS normal, only damage to Boss can start/resume timer.
+		if (GetWorldID() == 21018) {
+			if ((monsterId != 31310101) && (monsterId != 31310102)) {
+				return;
+			}
+		}
+	}
 
 	Start();
 	InsertPlayerInfo(id, totalDMG, soulstoneDMG, damageType, maxCombo, monsterID, skillID);


### PR DESCRIPTION
BS = Broken Savior

# Issue
Step 1. Phase 1 is finished and meter is also paused as tenebris's HP becomes 0
Step 2. Sometimes, normal monsters are remained there
Step 3. **_Players hit those normal monsters, and it resumes meter_**.

# Lazy Solution
If maze is BS normal, then totally ignore damage information about normal monster when meter is paused

# How meter works
Default situation
- DPS doesn't include normal monster
  ※ damage to normal monster is useless
- Hit/s includes normal monster
 ※ Hitting normal monster can help proc akashic / brooch / etc

If maze is BS normal and also meter is paused (**_added at this commit_**)
- Simply ignore all about normal monster