### PR TITLE
Update README.md (hotkey)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Soulworker DPS Meter for Global Server
 
 CTRL + DEL : Reset
 
-CTRL + END : Manual Pause/Resume
-
 You need to run dps meter before entering maze for viewing name and jobs (or not, all displays unknown)
 
 Also, USE AT YOUR OWN RISK


### PR DESCRIPTION
Manual Pause/Resume Feature was removed in the past to make dps meter more precise.
However, current readme file doesn't reflect this modifications.

# Details
Pause/Resume Button was removed : 
https://github.com/ga0321/SoulMeter/blob/b3ec75fbe545e4585273befa1c30cd68b2686c8a/Soulworker%20Utility/UI/PlayerTable.cpp#L169

Pause/Resume Hotkey was removed : 
https://github.com/ga0321/SoulMeter/blob/b3ec75fbe545e4585273befa1c30cd68b2686c8a/Soulworker%20Utility/UI/HotKey.cpp#L176

But current readme file doesn't reflect this modificaitons : 
https://github.com/ga0321/SoulMeter/blob/b3ec75fbe545e4585273befa1c30cd68b2686c8a/README.md?plain=1#L6